### PR TITLE
Add initial Streamlit starter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Streamlit Starter
+
+This repository provides a minimal Streamlit application.
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the app with:
+
+```bash
+streamlit run app.py
+```
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+st.title('Hello Streamlit!')
+
+st.write('Welcome to your Streamlit app.')
+
+if st.button('Click me'):
+    st.write('Button clicked!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
## Summary
- initialize minimal Streamlit app
- add README with setup instructions
- include `requirements.txt` listing dependencies

## Testing
- `python -m py_compile app.py`
- `pip install streamlit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841070f080483229b228d2d5485b9cb